### PR TITLE
Fix bug with remote states and implement secrets for remote state

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -144,3 +144,26 @@ pipeline:
       app_version: 1.0.0
     parallelism: 2
 ```
+
+## Remote configuration
+
+If you are configuring an s3 remote state and require S3 environment secrets you add the secrets "FOO" and "BAR" to your drone environment and reference the secrets as follows. These will not be outputted to stdout.
+
+```yaml
+pipeline:
+  terraform:
+    image: jmccann/drone-terraform:0.5
+    plan: false
+    remote:
+      backend: S3
+      config:
+        bucket: my-terraform-config-bucket
+        key: tf-states/my-project
+        region: us-east-1
+    vars:
+      app_name: my-project
+      app_version: 1.0.0
+    secrets:
+      AWS_ACCESS_KEY_ID: FOO
+      AWS_SECRET_ACCESS_KEY: BAR
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Docker image for Drone's terraform deployment plugin
 #
-#     CGO_ENABLED=0 go build -a -tags netgo
-#     docker build --rm=true -t plugins/drone-terraform .
+#     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo
+#     docker build --rm=true -t jmccann/drone-terraform .
 
 FROM gliderlabs/alpine:3.2
 RUN apk-install ca-certificates git

--- a/main.go
+++ b/main.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/joho/godotenv"
 	"github.com/Sirupsen/logrus"
+	"github.com/joho/godotenv"
 	"github.com/urfave/cli"
 )
 
@@ -24,53 +24,53 @@ func main() {
 		//
 
 		cli.BoolFlag{
-			Name: "plan",
-			Usage: "calculates a plan but does NOT apply it",
+			Name:   "plan",
+			Usage:  "calculates a plan but does NOT apply it",
 			EnvVar: "PLUGIN_PLAN",
 		},
 		cli.StringFlag{
-			Name: "remote",
-			Usage: "contains the configuration for the Terraform remote state tracking",
+			Name:   "remote",
+			Usage:  "contains the configuration for the Terraform remote state tracking",
 			EnvVar: "PLUGIN_REMOTE",
 		},
 		cli.StringFlag{
-			Name: "vars",
-			Usage: "a map of variables to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `<key>=<value>` option",
+			Name:   "vars",
+			Usage:  "a map of variables to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `<key>=<value>` option",
 			EnvVar: "PLUGIN_VARS",
 		},
 		cli.StringFlag{
-			Name: "secrets",
-			Usage: "a map of secrets to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `<key>=<ENV>` option",
+			Name:   "secrets",
+			Usage:  "a map of secrets to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `<key>=<ENV>` option",
 			EnvVar: "PLUGIN_SECRETS",
 		},
 		cli.StringFlag{
-			Name: "ca_cert",
-			Usage: "ca cert to add to your environment to allow terraform to use internal/private resources",
+			Name:   "ca_cert",
+			Usage:  "ca cert to add to your environment to allow terraform to use internal/private resources",
 			EnvVar: "PLUGIN_CA_CERT",
 		},
 		cli.BoolFlag{
-			Name: "sensitive",
-			Usage: "whether or not to suppress terraform commands to stdout",
+			Name:   "sensitive",
+			Usage:  "whether or not to suppress terraform commands to stdout",
 			EnvVar: "PLUGIN_SENSITIVE",
 		},
 		cli.StringFlag{
-			Name: "role_arn_to_assume",
-			Usage: "A role to assume before running the terraform commands",
+			Name:   "role_arn_to_assume",
+			Usage:  "A role to assume before running the terraform commands",
 			EnvVar: "PLUGIN_ROLE_ARN_TO_ASSUME",
 		},
 		cli.StringFlag{
-			Name: "root_dir",
-			Usage: "The root directory where the terraform files live. When unset, the top level directory will be assumed",
+			Name:   "root_dir",
+			Usage:  "The root directory where the terraform files live. When unset, the top level directory will be assumed",
 			EnvVar: "PLUGIN_ROOT_DIR",
 		},
 		cli.IntFlag{
-			Name: "parallelism",
-			Usage: "The number of concurrent operations as Terraform walks its graph",
+			Name:   "parallelism",
+			Usage:  "The number of concurrent operations as Terraform walks its graph",
 			EnvVar: "PLUGIN_PARALLELISM",
 		},
 
 		cli.StringFlag{
-			Name:	"env-file",
+			Name:  "env-file",
 			Usage: "source env file",
 		},
 	}
@@ -90,7 +90,7 @@ func run(c *cli.Context) error {
 	}
 
 	remote := Remote{}
-	json.Unmarshal([]byte(c.String("terraform.remote")), &remote)
+	json.Unmarshal([]byte(c.String("remote")), &remote)
 
 	var vars map[string]string
 	if c.String("vars") != "" {

--- a/plugin.go
+++ b/plugin.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
+	"github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -44,6 +44,9 @@ func (p Plugin) Exec() error {
 
 	var commands []*exec.Cmd
 	remote := p.Config.Remote
+	if len(p.Config.Secrets) != 0 {
+		exportSecrets(p.Config.Secrets)
+	}
 	if p.Config.Cacert != "" {
 		commands = append(commands, installCaCert(p.Config.Cacert))
 	}
@@ -91,6 +94,12 @@ func installCaCert(cacert string) *exec.Cmd {
 	return exec.Command(
 		"update-ca-certificates",
 	)
+}
+
+func exportSecrets(secrets map[string]string) {
+	for k, v := range secrets {
+		os.Setenv(fmt.Sprintf("%s", k), fmt.Sprintf("%s", os.Getenv(v)))
+	}
 }
 
 func deleteCache() *exec.Cmd {


### PR DESCRIPTION
I think I found a bug in the plugin, it looks for terraform.remote for the remote configuration.
It should just be looking under the "remote" key. Otherwise remote state configuration was being skipped.

Updated the documentation in the Dockerfile so that people can build this locally and test

Updated plugin.go -- Implemented exportSecrets
terraform remote configuration in some cases requires AWS credentials to grab the remote state, the current implementation did not allow for the secure use of those secrets.

Updated DOCS.md -- Adding documentation to use secrets for aws s3 remote configuration

I also ran go fmt on my stuff and it touched a few more places than I thought it would, but it's legit changes.