### PR TITLE
Update terraform version for docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 FROM gliderlabs/alpine:3.2
 RUN apk-install ca-certificates git
 
-ENV TERRAFORM_VERSION 0.7.5
+ENV TERRAFORM_VERSION 0.8.1
 
 RUN apk update && \
     wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.21-r2/glibc-2.21-r2.apk" && \


### PR DESCRIPTION
Major version was released. Old terraform versions are incompatible with newer terraform remote states produced by newer versions. This update will get rid of associated errors.