### PR TITLE
Fix bug in terraform.remote kev value lookup

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func run(c *cli.Context) error {
 	}
 
 	remote := Remote{}
-	json.Unmarshal([]byte(c.String("terraform.remote")), &remote)
+	json.Unmarshal([]byte(c.String("remote")), &remote)
 
 	var vars map[string]string
 	if c.String("vars") != "" {


### PR DESCRIPTION
terraform.remote isn't valid, you should check in remote for the config section under it