### PR TITLE
Implement exportSecrets

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -187,3 +187,26 @@ pipeline:
       app_version: 1.0.0
     parallelism: 2
 ```
+
+## Remote configuration
+
+If you are configuring an s3 remote state and require S3 environment secrets you add the secrets "FOO" and "BAR" to your drone environment and reference the secrets as follows. These will not be outputted to stdout.
+
+```yaml
+pipeline:
+  terraform:
+    image: jmccann/drone-terraform:0.5
+    plan: false
+    remote:
+      backend: S3
+      config:
+        bucket: my-terraform-config-bucket
+        key: tf-states/my-project
+        region: us-east-1
+    vars:
+      app_name: my-project
+      app_version: 1.0.0
+    secrets:
+      AWS_ACCESS_KEY_ID: FOO
+      AWS_SECRET_ACCESS_KEY: BAR
+```

--- a/plugin.go
+++ b/plugin.go
@@ -44,6 +44,11 @@ func (p Plugin) Exec() error {
 	}
 
 	var commands []*exec.Cmd
+
+	if len(p.Config.Secrets) != 0 {
+		exportSecrets(p.Config.Secrets)
+	}
+
 	remote := p.Config.Remote
 	if p.Config.Cacert != "" {
 		commands = append(commands, installCaCert(p.Config.Cacert))
@@ -92,6 +97,12 @@ func installCaCert(cacert string) *exec.Cmd {
 	return exec.Command(
 		"update-ca-certificates",
 	)
+}
+
+func exportSecrets(secrets map[string]string) {
+	for k, v := range secrets {
+		os.Setenv(fmt.Sprintf("%s", k), fmt.Sprintf("%s", os.Getenv(v)))
+	}
 }
 
 func deleteCache() *exec.Cmd {


### PR DESCRIPTION
Allows us to set environment variables that could be the named the same between multiple steps, but have different values due to enivronmental differences.

This is a redo of #28 because I'm bad at git. The secrets are exported so that they can be used in any other flag in this plugin.