### PR TITLE
Upgrade Terraform to 0.8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,20 @@
 #
 #     docker build --rm=true -t jmccann/drone-terraform:latest .
 
-FROM alpine:3.4
+FROM alpine:3.5
+
+ENV TERRAFORM_VERSION 0.8.7
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" | tee -a /etc/apk/repositories && \
   apk -U add \
     ca-certificates \
     git \
-    terraform && \
-  rm -rf /var/cache/apk/*
+	wget && \
+  rm -rf /var/cache/apk/* && \
+  wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \
+  unzip terraform.zip && \
+  rm terraform.zip && \
+  mv terraform /bin
 
 ADD drone-terraform /bin/
 ENTRYPOINT ["/bin/drone-terraform"]


### PR DESCRIPTION
Hey,

Thanks for your Drone plugin. We started using it, however Terraform appeared to be outdated. 

This PR is just a quick upgrade to the latest available Terraform version: 0.8.7 

Cheers