### PR TITLE
Tf 0.9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk -U add \
     wget && \
   rm -rf /var/cache/apk/*
 
-ENV TERRAFORM_VERSION 0.8.8
+ENV TERRAFORM_VERSION 0.9.4
 RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \
   unzip terraform.zip -d /bin && \
   rm -f terraform.zip

--- a/main.go
+++ b/main.go
@@ -95,9 +95,6 @@ func run(c *cli.Context) error {
 		_ = godotenv.Load(c.String("env-file"))
 	}
 
-	remote := Remote{}
-	json.Unmarshal([]byte(c.String("remote")), &remote)
-
 	var vars map[string]string
 	if c.String("vars") != "" {
 		if err := json.Unmarshal([]byte(c.String("vars")), &vars); err != nil {

--- a/main.go
+++ b/main.go
@@ -29,9 +29,9 @@ func main() {
 			EnvVar: "PLUGIN_PLAN",
 		},
 		cli.StringFlag{
-			Name:   "remote",
-			Usage:  "contains the configuration for the Terraform remote state tracking",
-			EnvVar: "PLUGIN_REMOTE",
+			Name:   "init_options",
+			Usage:  "options for the init command. See https://www.terraform.io/docs/commands/init.html",
+			EnvVar: "PLUGIN_INIT_OPTIONS",
 		},
 		cli.StringFlag{
 			Name:   "vars",
@@ -111,12 +111,15 @@ func run(c *cli.Context) error {
 		}
 	}
 
+	initOptions := InitOptions{}
+	json.Unmarshal([]byte(c.String("init_options")), &initOptions)
+
 	plugin := Plugin{
 		Config: Config{
-			Remote:      remote,
 			Plan:        c.Bool("plan"),
 			Vars:        vars,
 			Secrets:     secrets,
+			InitOptions: initOptions,
 			Cacert:      c.String("ca_cert"),
 			Sensitive:   c.Bool("sensitive"),
 			RoleARN:     c.String("role_arn_to_assume"),

--- a/plugin.go
+++ b/plugin.go
@@ -31,7 +31,7 @@ type (
 
 	InitOptions struct {
 		BackendConfig string `json:"backend-config"`
-		Lock          *bool  `json:"lock-state"`
+		Lock          *bool  `json:"lock"`
 		LockTimeout   string `json:"lock-timeout"`
 	}
 
@@ -125,12 +125,12 @@ func initCommand(config InitOptions) *exec.Cmd {
 		args = append(args, fmt.Sprintf("-backend-config=%s", config.BackendConfig))
 	}
 
-	// False is default
+	// True is default in TF
 	if config.Lock != nil {
 		args = append(args, fmt.Sprintf("-lock=%t", *config.Lock))
 	}
 
-	// "0s" is default
+	// "0s" is default in TF
 	if config.LockTimeout != "" {
 		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.LockTimeout))
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -29,11 +29,6 @@ type (
 		Targets     []string
 	}
 
-	Remote struct {
-		Backend string            `json:"backend"`
-		Config  map[string]string `json:"config"`
-	}
-
 	InitOptions struct {
 		BackendConfig string `json:"backend-config"`
 		Lock          *bool  `json:"lock-state"`

--- a/plugin.go
+++ b/plugin.go
@@ -130,7 +130,7 @@ func initCommand(config InitOptions) *exec.Cmd {
 		args = append(args, fmt.Sprintf("-backend-config=%s", config.BackendConfig))
 	}
 
-	// Fasle is default
+	// False is default
 	if config.Lock != nil {
 		args = append(args, fmt.Sprintf("-lock=%t", *config.Lock))
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -88,10 +88,6 @@ func (p Plugin) Exec() error {
 			trace(c)
 		}
 
-		logrus.WithFields(logrus.Fields{
-			"command": c.Args,
-		}).Debug("Running")
-
 		err := c.Run()
 		if err != nil {
 			logrus.WithFields(logrus.Fields{

--- a/plugin.go
+++ b/plugin.go
@@ -35,9 +35,9 @@ type (
 	}
 
 	InitOptions struct {
-		BackendConfig string `json:"backend_config"`
-		Lock          *bool  `json:"lock_state"`
-		LockTimeout   string `json:"lock_timeout"`
+		BackendConfig string `json:"backend-config"`
+		Lock          *bool  `json:"lock-state"`
+		LockTimeout   string `json:"lock-timeout"`
 	}
 
 	Plugin struct {


### PR DESCRIPTION
This adds support for the new `init` command in terraform. It accepts and sets most of the options for the command.

With introduction of the `init`, the `remote config` command was removed from terraform 0.9.x