### PR TITLE
Update to 9.5 as well as the new secrets for .6/.7 to work.

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -37,8 +37,9 @@ pipeline:
   terraform:
     image: jmccann/drone-terraform:1
     plan: false
-+   secrets:
++   terraform_secrets:
 +     my_secret: TERRAFORM_SECRET
++   secrets: [ TERRAFORM_SECRET ]
 ```
 
 You may be passing sensitive vars to your terraform commands.  If you do not want
@@ -151,9 +152,10 @@ pipeline:
         - "bucket=my-terraform-config-bucket"
         - "key=tf-states/my-project"
         - "region=us-east-1"
-+   secrets:
++   terraform_secrets:
 +     AWS_ACCESS_KEY_ID: DEV_AWS_ACCESS_KEY_ID
 +     AWS_SECRET_ACCESS_KEY: DEV_AWS_SECRET_ACCESS_KEY
++   secrets: [DEV_AWS_ACCESS_KEY_ID, DEV_AWS_SECRET_ACCESS_KEY]
 
   prod_terraform:
     image: jmccann/drone-terraform:1
@@ -163,9 +165,10 @@ pipeline:
         - "bucket=my-terraform-config-bucket"
         - "key=tf-states/my-project"
         - "region=us-east-1"
-+   secrets:
++   terraform_secrets:
 +     AWS_ACCESS_KEY_ID: PROD_AWS_ACCESS_KEY_ID
 +     AWS_SECRET_ACCESS_KEY: PROD_AWS_SECRET_ACCESS_KEY
++   secrets: [PROD_AWS_ACCESS_KEY_ID, PROD_AWS_SECRET_ACCESS_KEY]
 ```
 
 # Parameter Reference
@@ -195,7 +198,7 @@ var_files
 : a list of variable files to pass to the Terraform `plan` and `apply` commands.
 Each value is passed as a `-var-file <value>` option.
 
-secrets
+terraform_secrets
 : a map of variables to pass to the Terraform `plan` and `apply` commands as well as setting envvars.
 The `key` is the var and ENV to set.  The `value` is the ENV to read the value from.
 * Each entry generate a terraform var as follows: `-var <key>=$<value>`

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk -U add \
     wget && \
   rm -rf /var/cache/apk/*
 
-ENV TERRAFORM_VERSION 0.9.4
+ENV TERRAFORM_VERSION 0.9.5
 RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \
   unzip terraform.zip -d /bin && \
   rm -f terraform.zip

--- a/main.go
+++ b/main.go
@@ -39,9 +39,9 @@ func main() {
 			EnvVar: "PLUGIN_VARS",
 		},
 		cli.StringFlag{
-			Name:   "secrets",
+			Name:   "terraform_secrets",
 			Usage:  "a map of secrets to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `<key>=<ENV>` option",
-			EnvVar: "PLUGIN_SECRETS",
+			EnvVar: "PLUGIN_TERRAFORM_SECRETS",
 		},
 		cli.StringFlag{
 			Name:   "ca_cert",
@@ -108,8 +108,8 @@ func run(c *cli.Context) error {
 		}
 	}
 	var secrets map[string]string
-	if c.String("secrets") != "" {
-		if err := json.Unmarshal([]byte(c.String("secrets")), &secrets); err != nil {
+	if c.String("terraform_secrets") != "" {
+		if err := json.Unmarshal([]byte(c.String("terraform_secrets")), &secrets); err != nil {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
@jmccann I've upped the version to 9.5 for terraform as well as changed the secrets to be terraform_secrets because secrets is now used to decide what secrets get injected to the container and thus wouldn't work with the new versions of drone. It should still work with .5 as well if secrets is changed to terraform_secrets in the same way. Let me know if you need to to change anything or you see anything wrong