### PR TITLE
Destroy

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -168,6 +168,16 @@ pipeline:
 +     AWS_SECRET_ACCESS_KEY: PROD_AWS_SECRET_ACCESS_KEY
 ```
 
+Destroying the service can be done using the boolean `destory` option. Keep in mind that Fastly won't allow a service with active version be destoryed. Use `force_destroy` option in the service definition for terraform to handle it.
+
+```yaml
+pipeline:
+  destroy:
+    image: jmccann/drone-terraform:1
+    plan: false
++   destroy: true
+```
+
 # Parameter Reference
 
 plan
@@ -215,3 +225,6 @@ root_dir
 
 parallelism
 : The number of concurrent operations as Terraform walks its graph.
+
+destroy (boolean)
+: Destroys the service (still requires [`force_destroy`](https://www.terraform.io/docs/providers/fastly/r/service_v1.html#force_destroy) option to be set in the service definition)

--- a/main.go
+++ b/main.go
@@ -85,6 +85,11 @@ func main() {
 			Usage:  "a list of var files to use. Each value is passed as -var-file=<value>",
 			EnvVar: "PLUGIN_VAR_FILES",
 		},
+		cli.BoolFlag{
+			Name:   "destroy",
+			Usage:  "destory all resurces",
+			EnvVar: "PLUGIN_DESTROY",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -130,6 +135,7 @@ func run(c *cli.Context) error {
 			Parallelism: c.Int("parallelism"),
 			Targets:     c.StringSlice("targets"),
 			VarFiles:    c.StringSlice("var_files"),
+			Destroy:     c.Bool("destroy"),
 		},
 	}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func Test_destroyCommand(t *testing.T) {
+	type args struct {
+		config Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want *exec.Cmd
+	}{
+		{
+			"default",
+			args{config: Config{}},
+			exec.Command("terraform", "destroy", "-force"),
+		},
+		{
+			"with targets",
+			args{config: Config{Targets: []string{"target1", "target2"}}},
+			exec.Command("terraform", "destroy", "-target=target1", "-target=target2", "-force"),
+		},
+		{
+			"with parallelism",
+			args{config: Config{Parallelism: 5}},
+			exec.Command("terraform", "destroy", "-parallelism=5", "-force"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := destroyCommand(tt.args.config); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("destroyCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_applyCommand(t *testing.T) {
+	type args struct {
+		config Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want *exec.Cmd
+	}{
+		{
+			"default",
+			args{config: Config{}},
+			exec.Command("terraform", "apply", "plan.tfout"),
+		},
+		{
+			"with targets",
+			args{config: Config{Targets: []string{"target1", "target2"}}},
+			exec.Command("terraform", "apply", "--target", "target1", "--target", "target2", "plan.tfout"),
+		},
+		{
+			"with parallelism",
+			args{config: Config{Parallelism: 5}},
+			exec.Command("terraform", "apply", "-parallelism=5", "plan.tfout"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := applyCommand(tt.args.config); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("applyCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_terraformCommand(t *testing.T) {
+	type args struct {
+		config Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want *exec.Cmd
+	}{
+		{
+			"default",
+			args{config: Config{}},
+			exec.Command("terraform", "apply", "plan.tfout"),
+		},
+		{
+			"destroy",
+			args{config: Config{Destroy: true}},
+			exec.Command("terraform", "destroy", "-force"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := terraformCommand(tt.args.config); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("terraformCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_planCommand(t *testing.T) {
+	type args struct {
+		config Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want *exec.Cmd
+	}{
+		{
+			"default",
+			args{config: Config{}},
+			exec.Command("terraform", "plan", "-out=plan.tfout"),
+		},
+		{
+			"destroy",
+			args{config: Config{Destroy: true}},
+			exec.Command("terraform", "plan", "-destroy"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := planCommand(tt.args.config); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("planCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds support for the `destroy` command in terraform (and addresses #13).

It's implemented in a different way form what was discussed in the #13. The destroy is a standalone option to the plugin. This is for a couple of reasons:

1) There are rally only two terraform commands that interact with the service - `apply` and `destroy` and I do not think any other of the TF commands should be executed automatically in a plugin.
2) The `apply` and `destroy` use different options for the `plan` command. It would become unnecessarily too complicated to parse lists of commands passed and match different plan options for them (even though we're doing a simpler version of it in this PR)
3) A sequence of terraform commands still can be executed in a single pipeline if a remote state is used. In case of local state files, we can add an option where the state won't be wiped out after the terraform execution.

