### PR TITLE
Lock on all commands

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -196,10 +196,10 @@ specified multiple times. Flags specified later in the line override those
 specified earlier if they conflict.
 
 init_options.lock
-: Lock the state file when locking is supported.
+: Lock the state file when locking is supported. Default `true`.
 
 init_options.lock-timeout
-: Duration to retry a state lock.
+: Duration to wait for a state lock. Default `0s`.
 
 vars
 : a map of variables to pass to the Terraform `plan` and `apply` commands.

--- a/plugin.go
+++ b/plugin.go
@@ -210,6 +210,12 @@ func planCommand(config Config) *exec.Cmd {
 	if config.Parallelism > 0 {
 		args = append(args, fmt.Sprintf("-parallelism=%d", config.Parallelism))
 	}
+	if config.InitOptions.Lock != nil {
+		args = append(args, fmt.Sprintf("-lock=%t", *config.InitOptions.Lock))
+	}
+	if config.InitOptions.LockTimeout != "" {
+		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.InitOptions.LockTimeout))
+	}
 	return exec.Command(
 		"terraform",
 		args...,
@@ -234,6 +240,12 @@ func applyCommand(config Config) *exec.Cmd {
 	if config.Parallelism > 0 {
 		args = append(args, fmt.Sprintf("-parallelism=%d", config.Parallelism))
 	}
+	if config.InitOptions.Lock != nil {
+		args = append(args, fmt.Sprintf("-lock=%t", *config.InitOptions.Lock))
+	}
+	if config.InitOptions.LockTimeout != "" {
+		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.InitOptions.LockTimeout))
+	}
 	args = append(args, "plan.tfout")
 	return exec.Command(
 		"terraform",
@@ -250,6 +262,12 @@ func destroyCommand(config Config) *exec.Cmd {
 	}
 	if config.Parallelism > 0 {
 		args = append(args, fmt.Sprintf("-parallelism=%d", config.Parallelism))
+	}
+	if config.InitOptions.Lock != nil {
+		args = append(args, fmt.Sprintf("-lock=%t", *config.InitOptions.Lock))
+	}
+	if config.InitOptions.LockTimeout != "" {
+		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.InitOptions.LockTimeout))
 	}
 	args = append(args, "-force")
 	return exec.Command(


### PR DESCRIPTION
State locking configuration is not persisted with `terraform init`. The `-lock` and `-lock-timeout` flags must be passed to every invocation of terraform that touch the state file, so plan/apply/destroy.

This version is available now at `jrynyt2/drone-terraform:latest`

New output example:
```
$ terraform plan -out=plan.tfout -var env=dev -lock=true -lock-timeout=300s
```

If it waits, after some time:
```
Acquiring state lock. This may take a few moments...
```
