### PR TITLE
Updating to terraform 0.10.7 since the newest version now include the…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk -U add \
     wget && \
   rm -rf /var/cache/apk/*
 
-ENV TERRAFORM_VERSION 0.10.3
+ENV TERRAFORM_VERSION 0.10.7
 RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \
   unzip terraform.zip -d /bin && \
   rm -f terraform.zip


### PR DESCRIPTION
… registry for providers

With this https://github.com/jmccann/drone-terraform/pull/54 shouldn't be needed.

0.10.6 now includes the new provider registry which would make sense to make the default