### PR TITLE
Fix -var-file option to match terraform command format

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -312,7 +312,7 @@ func tfValidate(config Config) *exec.Cmd {
 		"validate",
 	}
 	for _, v := range config.VarFiles {
-		args = append(args, "-var-file", fmt.Sprintf("%s", v))
+		args = append(args, "-var-file=%s", fmt.Sprintf("%s", v))
 	}
 	for k, v := range config.Vars {
 		args = append(args, "-var")

--- a/plugin.go
+++ b/plugin.go
@@ -312,7 +312,7 @@ func tfValidate(config Config) *exec.Cmd {
 		"validate",
 	}
 	for _, v := range config.VarFiles {
-		args = append(args, "-var-file=%s", fmt.Sprintf("%s", v))
+		args = append(args, fmt.Sprintf("-var-file=%s", v))
 	}
 	for k, v := range config.Vars {
 		args = append(args, "-var")

--- a/plugin.go
+++ b/plugin.go
@@ -286,7 +286,7 @@ func tfPlan(config Config, destroy bool) *exec.Cmd {
 		args = append(args, "--target", fmt.Sprintf("%s", v))
 	}
 	for _, v := range config.VarFiles {
-		args = append(args, "-var-file", fmt.Sprintf("%s", v))
+		args = append(args, fmt.Sprintf("-var-file=%s", v))
 	}
 	for k, v := range config.Vars {
 		args = append(args, "-var")


### PR DESCRIPTION
When I used this plugin, I found the var_files option in drone-terraform plugin does not output correct format of -var-file for terraform command argument. Hence the changes.