### PR TITLE
Add ssh client and update golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Docker image for the Drone Terraform plugin
 #
 #     docker build -t jmccann/drone-terraform:latest .
-FROM golang:1.9-alpine AS builder
+FROM golang:1.10-alpine AS builder
 COPY ./*.go ./src/
 COPY ./vendor/ ./src/
 RUN set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ FROM alpine:3.7
 RUN apk -U add \
     ca-certificates \
     git \
-    wget && \
-  rm -rf /var/cache/apk/*
+    wget \
+    openssh-client && \
+    rm -rf /var/cache/apk/*
 
 ENV TERRAFORM_VERSION 0.11.7
 RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \


### PR DESCRIPTION
Terraform can get modules from git repos over ssh. This needs ssh binary to be available.

Without it it fails with
```
Error downloading modules: Error loading modules: error downloading 'ssh://git@bitbucket.org/potential-ly/tf-modules.git': /usr/bin/git exited with 128: Cloning into '.terraform/modules/f31fb38c937f952e6dbb9110ffec4233'...
fatal: cannot run ssh: No such file or directory
fatal: unable to fork
```

Additionally this updates golang to the latest. 