### PR TITLE
Include aws cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ RUN apk -U add \
     ca-certificates \
     git \
     wget \
-    openssh-client && \
+    openssh-client \
+    python \
+    py-pip  && \
+    pip install --upgrade awscli && \
+    apk -v --purge del py-pip && \
     rm -rf /var/cache/apk/*
 
 ENV TERRAFORM_VERSION 0.11.7


### PR DESCRIPTION
I've created this PR to add the aws-cli to the image.
 
The reason for this is that not all AWS services are available on terraform and some that do have limitations (SecretsManager for example). By including the cli in the image we can extend terraform functionality by using local-exec with the cli to close the loop.
 
We can easily pass env vars to the image to set up the awscli or use instance profiles on the drone instances if running it on AWS.

Given that terraform is largely used with AWS and the great flexibility that this provides us I'd like you to consider merging this PR.