### PR TITLE
Allow specifying the Terraform version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apk -U add \
     openssh-client && \
     rm -rf /var/cache/apk/*
 
-ENV TERRAFORM_VERSION 0.11.7
+ARG TERRAFORM_VERSION=0.11.7
 RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \
   unzip terraform.zip -d /bin && \
   rm -f terraform.zip


### PR DESCRIPTION
Main use case is to **upgrade to a newer version without having to wait for this plugin to be updated**.

More specifically, currently I'm having a pipeline failing because it's using Terraform 0.11.7 on a backend state that was modified (locally, by me) with Terraform 0.11.8.

This is the error I get:

> Error: 
Terraform doesn't allow running any operations against a state
that was written by a future Terraform version. The state is
reporting it is written by Terraform '0.11.8'
> 
> Please run at least that version of Terraform to continue.