### PR TITLE
Added support for parallel execution

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -196,6 +196,19 @@ pipeline:
 +     check: true
 ```
 
+You may want to run some executions in parallel without having racing condition problems with the .terraform dir and 
+plan's output file.
+
+```diff
+pipeline:
+  backend-service:
+    image: jmccann/drone-terraform:<version>
++   tf_data_dir: .backend-service.terraform
+  frontend-service:
+    image: jmccann/drone-terraform:<version>
++   tf_data_dir: .frontend-service.terraform
+```
+
 # Parameter Reference
 
 actions
@@ -253,3 +266,6 @@ root_dir
 
 parallelism
 : The number of concurrent operations as Terraform walks its graph.
+
+tf_data_dir
+: changes the location where Terraform keeps its per-working-directory data, such as the current remote backend configuration.

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:   "tf_data_dir",
-			Usage:  "changes the location where Terraform keeps its per-working-directory data, such as the current remote backend configuration.",
+			Usage:  "changes the location where Terraform keeps its per-working-directory data, such as the current remote backend configuration",
 			EnvVar: "PLUGIN_TF_DATA_DIR",
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -108,6 +108,11 @@ func main() {
 			Usage:  "a list of var files to use. Each value is passed as -var-file=<value>",
 			EnvVar: "PLUGIN_VAR_FILES",
 		},
+		cli.StringSliceFlag{
+			Name:   "tf_data_dir",
+			Usage:  "changes the location where Terraform keeps its per-working-directory data, such as the current remote backend configuration.",
+			EnvVar: "PLUGIN_TF_DATA_DIR",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -144,18 +149,19 @@ func run(c *cli.Context) error {
 
 	plugin := Plugin{
 		Config: Config{
-			Actions:     c.StringSlice("actions"),
-			Vars:        vars,
-			Secrets:     secrets,
-			InitOptions: initOptions,
-			FmtOptions:  fmtOptions,
-			Cacert:      c.String("ca_cert"),
-			Sensitive:   c.Bool("sensitive"),
-			RoleARN:     c.String("role_arn_to_assume"),
-			RootDir:     c.String("root_dir"),
-			Parallelism: c.Int("parallelism"),
-			Targets:     c.StringSlice("targets"),
-			VarFiles:    c.StringSlice("var_files"),
+			Actions:          c.StringSlice("actions"),
+			Vars:             vars,
+			Secrets:          secrets,
+			InitOptions:      initOptions,
+			FmtOptions:       fmtOptions,
+			Cacert:           c.String("ca_cert"),
+			Sensitive:        c.Bool("sensitive"),
+			RoleARN:          c.String("role_arn_to_assume"),
+			RootDir:          c.String("root_dir"),
+			Parallelism:      c.Int("parallelism"),
+			Targets:          c.StringSlice("targets"),
+			VarFiles:         c.StringSlice("var_files"),
+			TerraformDataDir: c.String("tf_data_dir"),
 		},
 		Netrc: Netrc{
 			Login:    c.String("netrc.username"),

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 			Usage:  "a list of var files to use. Each value is passed as -var-file=<value>",
 			EnvVar: "PLUGIN_VAR_FILES",
 		},
-		cli.StringSliceFlag{
+		cli.StringFlag{
 			Name:   "tf_data_dir",
 			Usage:  "changes the location where Terraform keeps its per-working-directory data, such as the current remote backend configuration.",
 			EnvVar: "PLUGIN_TF_DATA_DIR",

--- a/plugin.go
+++ b/plugin.go
@@ -382,7 +382,10 @@ func createEnvironmentVariables(config Config) []string {
 
 func createTerraformCommand(config Config, args ...string) *exec.Cmd {
 	command := exec.Command("terraform", args...)
-	command.Env = append(command.Env, createEnvironmentVariables(config)...)
+	environmentVariables := createEnvironmentVariables(config)
+	if len(environmentVariables) > 0 {
+		command.Env = append(os.Environ(), environmentVariables...)
+	}
 	return command
 }
 func getTfoutPath(config Config) string {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -212,49 +212,32 @@ func TestPlugin(t *testing.T) {
 			}
 
 			tests := []struct {
-				name            string
-				args            args
-				want            *exec.Cmd
-				expectedEnvVars []string
+				name string
+				args args
+				want *exec.Cmd
 			}{
 				{
 					"with TerraformDataDir",
 					args{config: Config{TerraformDataDir: ".overriden_terraform_dir"}},
 					exec.Command("terraform", "apply", ".overriden_terraform_dir.plan.tfout"),
-					[]string{"TF_DATA_DIR=.overriden_terraform_dir"},
 				},
 				{
 					"with TerraformDataDir value as .terraform",
 					args{config: Config{TerraformDataDir: ".terraform"}},
 					exec.Command("terraform", "apply", "plan.tfout"),
-					[]string{},
 				},
 				{
 					"without TerraformDataDir",
 					args{config: Config{}},
 					exec.Command("terraform", "apply", "plan.tfout"),
-					[]string{},
 				},
 			}
 
 			for _, tt := range tests {
+				os.Setenv("TF_DATA_DIR", tt.args.config.TerraformDataDir)
 				applied := tfApply(tt.args.config)
-				appliedEnv := applied.Env
-				applied.Env = nil
 
 				g.Assert(applied).Equal(tt.want)
-
-				var found int = 0
-
-				for _, expectedEnvVar := range tt.expectedEnvVars {
-					for _, env := range appliedEnv {
-						if expectedEnvVar == env {
-							found += 1
-							break
-						}
-					}
-				}
-				g.Assert(found).Equal(len(tt.expectedEnvVars))
 
 			}
 		})

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -204,4 +204,59 @@ func TestPlugin(t *testing.T) {
 			}
 		})
 	})
+
+	g.Describe("tfDataDir", func() {
+		g.It("Should override the terraform data dir environment variable when provided", func() {
+			type args struct {
+				config Config
+			}
+
+			tests := []struct {
+				name            string
+				args            args
+				want            *exec.Cmd
+				expectedEnvVars []string
+			}{
+				{
+					"with TerraformDataDir",
+					args{config: Config{TerraformDataDir: ".overriden_terraform_dir"}},
+					exec.Command("terraform", "apply", ".overriden_terraform_dir.plan.tfout"),
+					[]string{"TF_DATA_DIR=.overriden_terraform_dir"},
+				},
+				{
+					"with TerraformDataDir value as .terraform",
+					args{config: Config{TerraformDataDir: ".terraform"}},
+					exec.Command("terraform", "apply", "plan.tfout"),
+					[]string{},
+				},
+				{
+					"without TerraformDataDir",
+					args{config: Config{}},
+					exec.Command("terraform", "apply", "plan.tfout"),
+					[]string{},
+				},
+			}
+
+			for _, tt := range tests {
+				applied := tfApply(tt.args.config)
+				appliedEnv := applied.Env
+				applied.Env = nil
+
+				g.Assert(applied).Equal(tt.want)
+
+				var found int = 0
+
+				for _, expectedEnvVar := range tt.expectedEnvVars {
+					for _, env := range appliedEnv {
+						if expectedEnvVar == env {
+							found += 1
+							break
+						}
+					}
+				}
+				g.Assert(found).Equal(len(tt.expectedEnvVars))
+
+			}
+		})
+	})
 }


### PR DESCRIPTION
This commit will enable the plugin to do parallel builds.

Changes: 

- Use Terraform's TF_DATA_DIR environment variable to change the state directory so they will not conflict each other in parallel executions (**.terraform**).
- change the plan's output (**plan.tfout**) to a different file so they will not be overriden by another parallel execution.
- Make the deletion of the correct terraform cache before running plan command (**rm -rf**).
- Created the parameter ** tf_data_dir** in the plugin to have a drone standard way of using it instead of the environment variable if the user wants/prefers.

I've guaranteed in this PR that there's no backward compatibility breaks, so for the people that uses it, nothing is expected to change.