### PR TITLE
move terraform version to a docker build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN apk -U add \
     openssh-client && \
     rm -rf /var/cache/apk/*
 
-ENV TERRAFORM_VERSION 0.12.4
-RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \
+ARG terraform_version
+RUN wget -q https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_linux_amd64.zip -O terraform.zip && \
   unzip terraform.zip -d /bin && \
   rm -f terraform.zip
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ go build
 Build the docker image with the following commands:
 
 ```
-docker build --rm=true -t jmccann/drone-terraform .
+docker build --rm=true \
+  -t jmccann/drone-terraform \
+  --build-arg terraform_version=0.12.0 .
 ```
 
 ## Usage

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -13,7 +13,7 @@ major=$(echo $tag | awk -F. '{print $1}')
 minor=$(echo $tag | awk -F. '{print $2}')
 # patch=$(echo $tag | awk -F. '{print $3}')
 
-tf_ver=$(grep TERRAFORM_VERSION Dockerfile | head -n 1 | awk '{print $3}')
+tf_ver="0.12.4"
 
 echo "Confirm building images for:"
 echo "  MAJOR: ${major}"
@@ -28,7 +28,7 @@ if [[ "$ans" != "Y" && "$ans" != "y" ]]; then
 fi
 
 set -x
-docker build -t jmccann/drone-terraform:latest .
+docker build -t jmccann/drone-terraform:latest --build-arg terraform_version=${tf_ver} .
 
 docker tag jmccann/drone-terraform:latest jmccann/drone-terraform:${major}
 docker tag jmccann/drone-terraform:latest jmccann/drone-terraform:${major}.${minor}


### PR DESCRIPTION
This also opens things up to build images for multiple terraform versions.

...Which leads to a bit of a shameless ask: any chance of a 0.11.14 version? The [0.12 upgrade guide](https://www.terraform.io/upgrade-guides/0-12.html) recommends upgrading to 0.11.14 before making the leap to 0.12.x, so being able to run 0.11.14 in ci would be super useful.