### PR TITLE
Loading credentials from env_file parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 6.2-0.12.11 (2019-11-25)
-**BREAKING CHANGE**
-* Changed `env-file` param to `env_file` to make it consistent with other parameters
-* Added `env_file` param to the plugin config
-
 ## 6.1-0.12.11 (2019-10-18)
 * Update embedded TF to `0.12.11`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.2-0.12.11 (2019-11-25)
+**BREAKING CHANGE**
+* Changed `env-file` param to `env_file` to make it consistent with other parameters
+* Added `env_file` param to the plugin config
+
 ## 6.1-0.12.11 (2019-10-18)
 * Update embedded TF to `0.12.11`
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/franela/goblin v0.0.0-20170111051028-2fa789fd0c6b
 	github.com/go-ini/ini v1.21.1
 	github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7
-	github.com/joho/godotenv v0.0.0-20150907010228-4ed13390c0ac
+	github.com/joho/godotenv v1.3.0
 	github.com/urfave/cli v0.0.0-20161006035353-55f715e28c46
 	golang.org/x/sys v0.0.0-20161006025142-8d1157a43547
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7 h1:SMvOWPJCES
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joho/godotenv v0.0.0-20150907010228-4ed13390c0ac h1:wF2VgtpbaLqhBHV9FxVWzgzgv8VcCjZ66Bl/+F6cpT0=
 github.com/joho/godotenv v0.0.0-20150907010228-4ed13390c0ac/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/urfave/cli v0.0.0-20161006035353-55f715e28c46 h1:EztUvugq7AA7F3lYLmtFQyvKdcY5pisPt10DqPjRCL8=
 github.com/urfave/cli v0.0.0-20161006035353-55f715e28c46/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 golang.org/x/sys v0.0.0-20161006025142-8d1157a43547/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/joho/godotenv"
 	"github.com/urfave/cli"
 )
 
@@ -35,8 +34,9 @@ func main() {
 			EnvVar: "PLUGIN_CA_CERT",
 		},
 		cli.StringFlag{
-			Name:  "env-file",
-			Usage: "source env file",
+			Name:   "env_file",
+			Usage:  "pass filename to source it and load variables into current shell",
+			EnvVar: "PLUGIN_ENV_FILE",
 		},
 		cli.StringFlag{
 			Name:   "init_options",
@@ -125,10 +125,6 @@ func run(c *cli.Context) error {
 		"Revision": revision,
 	}).Info("Drone Terraform Plugin Version")
 
-	if c.String("env-file") != "" {
-		_ = godotenv.Load(c.String("env-file"))
-	}
-
 	var vars map[string]string
 	if c.String("vars") != "" {
 		if err := json.Unmarshal([]byte(c.String("vars")), &vars); err != nil {
@@ -161,6 +157,7 @@ func run(c *cli.Context) error {
 			Parallelism:      c.Int("parallelism"),
 			Targets:          c.StringSlice("targets"),
 			VarFiles:         c.StringSlice("var_files"),
+			EnvFile:          c.String("env_file"),
 			TerraformDataDir: c.String("tf_data_dir"),
 		},
 		Netrc: Netrc{

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/joho/godotenv"
 	"github.com/urfave/cli"
 )
 
@@ -125,6 +126,10 @@ func run(c *cli.Context) error {
 		"Revision": revision,
 	}).Info("Drone Terraform Plugin Version")
 
+	if c.String("env_file") != "" {
+		_ = godotenv.Load(c.String("env_file"))
+	}
+
 	var vars map[string]string
 	if c.String("vars") != "" {
 		if err := json.Unmarshal([]byte(c.String("vars")), &vars); err != nil {
@@ -157,7 +162,6 @@ func run(c *cli.Context) error {
 			Parallelism:      c.Int("parallelism"),
 			Targets:          c.StringSlice("targets"),
 			VarFiles:         c.StringSlice("var_files"),
-			EnvFile:          c.String("env_file"),
 			TerraformDataDir: c.String("tf_data_dir"),
 		},
 		Netrc: Netrc{

--- a/plugin.go
+++ b/plugin.go
@@ -172,11 +172,11 @@ func CopyTfEnv() {
 func credsSet() bool {
 	awsTokens := []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"}
 	for _, token := range awsTokens {
-		if os.Getenv(token) != "" {
-			return true
+		if os.Getenv(token) == "" {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func assumeRole(roleArn string) {

--- a/plugin.go
+++ b/plugin.go
@@ -77,7 +77,7 @@ func (p Plugin) Exec() error {
 		}
 	}
 
-	if p.Config.RoleARN != "" {
+	if p.Config.RoleARN != "" && !credsSet() {
 		assumeRole(p.Config.RoleARN)
 	}
 
@@ -169,14 +169,17 @@ func CopyTfEnv() {
 	}
 }
 
-func assumeRole(roleArn string) bool {
+func credsSet() bool {
 	awsTokens := []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"}
 	for _, token := range awsTokens {
 		if os.Getenv(token) != "" {
 			return true
 		}
 	}
+	return false
+}
 
+func assumeRole(roleArn string) {
 	client := sts.New(session.New())
 	duration := time.Hour * 1
 	stsProvider := &stscreds.AssumeRoleProvider{
@@ -195,8 +198,6 @@ func assumeRole(roleArn string) bool {
 	os.Setenv("AWS_ACCESS_KEY_ID", value.AccessKeyID)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", value.SecretAccessKey)
 	os.Setenv("AWS_SESSION_TOKEN", value.SessionToken)
-
-	return true
 }
 
 func deleteCache(terraformDataDir string) *exec.Cmd {

--- a/plugin.go
+++ b/plugin.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/joho/godotenv"
 )
 
 type (
@@ -34,7 +33,6 @@ type (
 		Parallelism      int
 		Targets          []string
 		VarFiles         []string
-		EnvFile          string
 		TerraformDataDir string
 	}
 
@@ -77,10 +75,6 @@ func (p Plugin) Exec() error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if p.Config.EnvFile != "" {
-		_ = godotenv.Load(p.Config.EnvFile)
 	}
 
 	if p.Config.RoleARN != "" {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,12 +1,26 @@
 package main
 
 import (
+	"log"
 	"os"
 	"os/exec"
 	"testing"
 
 	. "github.com/franela/goblin"
+	"github.com/joho/godotenv"
 )
+
+func loadEnv(keyValue string) {
+	const FileName = "./.env_example"
+	env, err := godotenv.Unmarshal(keyValue)
+	err = godotenv.Write(env, FileName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(FileName)
+
+	_ = godotenv.Load(FileName)
+}
 
 func TestPlugin(t *testing.T) {
 	g := Goblin(t)
@@ -25,6 +39,63 @@ func TestPlugin(t *testing.T) {
 			g.Assert(os.Getenv("TF_VAR_something_else")).Equal("some other value")
 			g.Assert(os.Getenv("TF_VAR_base64")).Equal("dGVzdA==")
 		})
+	})
+
+	g.Describe("credsSet", func() {
+		var awsAccessKeyID string
+		var awsSecretAccessKey string
+		var awsSessionToken string
+
+		g.Before(func() {
+			awsAccessKeyID = os.Getenv("AWS_ACCESS_KEY_ID")
+			awsSecretAccessKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+			awsSessionToken = os.Getenv("AWS_SESSION_TOKEN")
+		})
+
+		// Restoring all credentials after running the credsSet test
+		g.After(func() {
+			os.Setenv("AWS_ACCESS_KEY_ID", awsAccessKeyID)
+			os.Setenv("AWS_SECRET_ACCESS_KEY", awsSecretAccessKey)
+			os.Setenv("AWS_SESSION_TOKEN", awsSessionToken)
+		})
+
+		type args struct {
+			config string
+		}
+
+		tests := []struct {
+			name string
+			args args
+			want bool
+		}{
+			{
+				"Should return true when all credentials were set",
+				args{config: "AWS_ACCESS_KEY_ID=access_key_id1\nAWS_SECRET_ACCESS_KEY=secret_access_key1\nAWS_SESSION_TOKEN=session_token1"},
+				true,
+			},
+			{
+				"Should return false when access key id is missing",
+				args{config: "AWS_SECRET_ACCESS_KEY=secret_access_key2\nAWS_SESSION_TOKEN=session_token2"},
+				false,
+			},
+			{
+				"Should return false when secret access key is missing",
+				args{config: "AWS_ACCESS_KEY_ID=access_key_id3\nAWS_SESSION_TOKEN=session_token3"},
+				false,
+			},
+			{
+				"Should return false when session token is missing",
+				args{config: "AWS_ACCESS_KEY_ID=access_key_id4\nAWS_SECRET_ACCESS_KEY=secret_access_key4"},
+				false,
+			},
+		}
+
+		for _, tt := range tests {
+			g.It(tt.name, func() {
+				loadEnv(tt.args.config)
+				g.Assert(credsSet()).Equal(tt.want)
+			})
+		}
 	})
 
 	g.Describe("tfApply", func() {


### PR DESCRIPTION
## Use Cases
- As a developer, I would like to have a way to ignore assumeRole authentication if I already have the credentials from another custom plugin. Now the behaviour is always run the assumeRole function.

- The single responsibility of drone-terraform should be running terraform as a drone plugin not authenticating behind the scenes. I want to pass the credentials somehow to drone-terraform plugin.

- Due the limitations on the host machine, I can't store the _~/.aws/credentials_ file and without the admin keys the drone-terraform will fail. This is a real case with Cloud Drone because we can't store files there, the only way to run the drone-terraform is reading the credentials from a temporary file created by [another custom plugin](https://github.com/neemiasjnr/drone-aws-role-auth). Without this PR is not possible to run the drone-terraform on Cloud Drone.

- Due security reasons, I don't want to pass the Admin AWS tokens for drone plugins, I want to use my custom plugin to generate the session tokens and load the .env file on drone-terraform with the temporary credentials.

## Solutions
Actually I needed to change 2 things:
1. add the env_file as a plugin param
2. skip the assumeRole if the aws tokens are already set (by the load env)

I also introduced a breaking change by changing CLI param env-file to env_file

I did it mainly for 3 reasons:
- Make it consistent with other params that uses underscore. There is no parameter with dash actually;
- No one using the plugin will be impacted, I assume most users will not be impacted;
- Since the property was introduced two years ago and not implemented as plugin parameter, is not a feature with so much demand since then, the impact should not be big for most users.

@jmccann does that make sense to you? I'm happy to discuss and also revert that breaking change if you have a concern.

## Core Changes
- Extending the CLI env-file to a plugin parameter
- Skipping the assumeRole function if credentials have been created before