### PR TITLE
Add curl binary to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     ca-certificates \
     git \
     wget \
+    curl \
     openssh-client
 
 ARG terraform_version


### PR DESCRIPTION
We are using AWS EKS Terraform module which requires curl package to check an endpoint:
https://github.com/terraform-aws-modules/terraform-aws-eks/blob/626a393ab964677e3b4fb1336ad9d8cef4c26406/variables.tf#L204

Currently using this plugin it gets stuck on that wait since the curl command is not found.