### PR TITLE
add the -refresh option to plan and apply

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -229,6 +229,9 @@ init_options.lock
 init_options.lock-timeout
 : Duration to wait for a state lock. Default `0s`.
 
+init_options.refresh
+: Update the state for each resource prior to planning and applying. Default `true`.
+
 fmt_options
 : contains the configuration for the fmt action.
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -229,9 +229,6 @@ init_options.lock
 init_options.lock-timeout
 : Duration to wait for a state lock. Default `0s`.
 
-init_options.refresh
-: Update the state for each resource prior to planning and applying. Default `true`.
-
 fmt_options
 : contains the configuration for the fmt action.
 
@@ -272,3 +269,6 @@ parallelism
 
 tf_data_dir
 : changes the location where Terraform keeps its per-working-directory data, such as the current remote backend configuration.
+
+disable_refresh
+: (default: `false`) - whether or not to disable refreshing state before `plan` and `apply` commands.

--- a/main.go
+++ b/main.go
@@ -114,6 +114,11 @@ func main() {
 			Usage:  "changes the location where Terraform keeps its per-working-directory data, such as the current remote backend configuration",
 			EnvVar: "PLUGIN_TF_DATA_DIR",
 		},
+		cli.BoolFlag{
+			Name:   "disable_refresh",
+			Usage:  "whether or not to disable refreshing state before `plan` and `apply` commands",
+			EnvVar: "PLUGIN_DISABLE_REFRESH",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -163,6 +168,7 @@ func run(c *cli.Context) error {
 			Targets:          c.StringSlice("targets"),
 			VarFiles:         c.StringSlice("var_files"),
 			TerraformDataDir: c.String("tf_data_dir"),
+			DisableRefresh:   c.Bool("disable_refresh"),
 		},
 		Netrc: Netrc{
 			Login:    c.String("netrc.username"),

--- a/plugin.go
+++ b/plugin.go
@@ -48,6 +48,7 @@ type (
 		BackendConfig []string `json:"backend-config"`
 		Lock          *bool    `json:"lock"`
 		LockTimeout   string   `json:"lock-timeout"`
+		Refresh       *bool    `json:"refresh"`
 	}
 
 	// FmtOptions fmt options for the Terraform's fmt command
@@ -234,6 +235,11 @@ func initCommand(config InitOptions) *exec.Cmd {
 		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.LockTimeout))
 	}
 
+	// True is default in TF
+	if config.Refresh != nil {
+		args = append(args, fmt.Sprintf("-refresh=%t", *config.Refresh))
+	}
+
 	// Fail Terraform execution on prompt
 	args = append(args, "-input=false")
 
@@ -269,6 +275,9 @@ func tfApply(config Config) *exec.Cmd {
 	}
 	if config.InitOptions.LockTimeout != "" {
 		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.InitOptions.LockTimeout))
+	}
+	if config.InitOptions.Refresh != nil {
+		args = append(args, fmt.Sprintf("-refresh=%t", *config.InitOptions.Refresh))
 	}
 	args = append(args, getTfoutPath())
 
@@ -327,6 +336,9 @@ func tfPlan(config Config, destroy bool) *exec.Cmd {
 	}
 	if config.InitOptions.LockTimeout != "" {
 		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.InitOptions.LockTimeout))
+	}
+	if config.InitOptions.Refresh != nil {
+		args = append(args, fmt.Sprintf("-refresh=%t", *config.InitOptions.Refresh))
 	}
 	return exec.Command(
 		"terraform",

--- a/plugin.go
+++ b/plugin.go
@@ -34,6 +34,7 @@ type (
 		Targets          []string
 		VarFiles         []string
 		TerraformDataDir string
+		DisableRefresh   bool
 	}
 
 	// Netrc is credentials for cloning
@@ -48,7 +49,6 @@ type (
 		BackendConfig []string `json:"backend-config"`
 		Lock          *bool    `json:"lock"`
 		LockTimeout   string   `json:"lock-timeout"`
-		Refresh       *bool    `json:"refresh"`
 	}
 
 	// FmtOptions fmt options for the Terraform's fmt command
@@ -235,11 +235,6 @@ func initCommand(config InitOptions) *exec.Cmd {
 		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.LockTimeout))
 	}
 
-	// True is default in TF
-	if config.Refresh != nil {
-		args = append(args, fmt.Sprintf("-refresh=%t", *config.Refresh))
-	}
-
 	// Fail Terraform execution on prompt
 	args = append(args, "-input=false")
 
@@ -276,8 +271,8 @@ func tfApply(config Config) *exec.Cmd {
 	if config.InitOptions.LockTimeout != "" {
 		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.InitOptions.LockTimeout))
 	}
-	if config.InitOptions.Refresh != nil {
-		args = append(args, fmt.Sprintf("-refresh=%t", *config.InitOptions.Refresh))
+	if config.DisableRefresh {
+		args = append(args, "-refresh=false")
 	}
 	args = append(args, getTfoutPath())
 
@@ -337,8 +332,8 @@ func tfPlan(config Config, destroy bool) *exec.Cmd {
 	if config.InitOptions.LockTimeout != "" {
 		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.InitOptions.LockTimeout))
 	}
-	if config.InitOptions.Refresh != nil {
-		args = append(args, fmt.Sprintf("-refresh=%t", *config.InitOptions.Refresh))
+	if config.DisableRefresh {
+		args = append(args, "-refresh=false")
 	}
 	return exec.Command(
 		"terraform",


### PR DESCRIPTION
-refresh=true - Update the state for each resource prior to planning and applying. This has no effect if a plan file is given directly to apply.