### PR TITLE
Remove -lock and -lock-timeout for terraform init

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -225,16 +225,6 @@ func initCommand(config InitOptions) *exec.Cmd {
 		args = append(args, fmt.Sprintf("-backend-config=%s", v))
 	}
 
-	// True is default in TF
-	if config.Lock != nil {
-		args = append(args, fmt.Sprintf("-lock=%t", *config.Lock))
-	}
-
-	// "0s" is default in TF
-	if config.LockTimeout != "" {
-		args = append(args, fmt.Sprintf("-lock-timeout=%s", config.LockTimeout))
-	}
-
 	// Fail Terraform execution on prompt
 	args = append(args, "-input=false")
 


### PR DESCRIPTION
In order to use lock options in plan and apply, they have to be passed in `init_options`.
However, these options are used in `terraform init`.
But in 0.15, `init` no longer accepts these options.

Currently this blocks the use of lock options in 0.15 or higher.

Ideally these options are moved out of `init` into another parameter (like `options`).

https://www.terraform.io/upgrade-guides/0-15.html#other-minor-command-line-behavior-changes

> The -lock and -lock-timeout options are no longer available for the terraform init command. Locking applies to operations that can potentially change remote objects, to help ensure that two concurrent Terraform processes don't try to run conflicting operations, but terraform init does not interact with any providers in order to possibly effect such changes.
> These options didn't do anything in the terraform init command before, and so you can remove them from any automated calls with no change in behavior.