### PR TITLE
Adds recursive option to fmt

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -194,6 +194,7 @@ pipeline:
 +     write: false
 +     diff: true
 +     check: true
++     recursive: true
 ```
 
 You may want to run some executions in parallel without having racing condition problems with the .terraform dir and 
@@ -243,6 +244,9 @@ fmt_options.diff
 
 fmt_options.check
 : Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise. Default `false`.
+
+fmt_options.recursive
+: Process files in subdirectories as well. Default `false`.
 
 vars
 : a map of variables to pass to the Terraform `plan` and `apply` commands.

--- a/plugin.go
+++ b/plugin.go
@@ -57,6 +57,7 @@ type (
 		Write *bool `json:"write"`
 		Diff  *bool `json:"diff"`
 		Check *bool `json:"check"`
+		Recursive *bool `json:"recursive"`
 	}
 
 	// Plugin represents the plugin instance to be executed
@@ -363,6 +364,9 @@ func tfFmt(config Config) *exec.Cmd {
 	}
 	if config.FmtOptions.Check != nil {
 		args = append(args, fmt.Sprintf("-check=%t", *config.FmtOptions.Check))
+	}
+	if config.FmtOptions.Recursive != nil {
+		args = append(args, fmt.Sprintf("-recursive=%t", *config.FmtOptions.Recursive))
 	}
 	return exec.Command(
 		"terraform",

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -244,14 +244,20 @@ func TestPlugin(t *testing.T) {
 					exec.Command("terraform", "fmt", "-check=true"),
 				},
 				{
+					"with recursive",
+					args{config: Config{FmtOptions: FmtOptions{Recursive: &affirmative}}},
+					exec.Command("terraform", "fmt", "-recursive=true"),
+				},
+				{
 					"with combination",
 					args{config: Config{FmtOptions: FmtOptions{
 						List:  &negative,
 						Write: &negative,
 						Diff:  &affirmative,
 						Check: &affirmative,
+						Recursive: &affirmative,
 					}}},
-					exec.Command("terraform", "fmt", "-list=false", "-write=false", "-diff=true", "-check=true"),
+					exec.Command("terraform", "fmt", "-list=false", "-write=false", "-diff=true", "-check=true", "-recursive=true"),
 				},
 			}
 


### PR DESCRIPTION
Enables `-recursive` flag in [terraform fmt](https://www.terraform.io/docs/cli/commands/fmt.html#recursive).