### PR TITLE
feat: Enable using flag -detailed-exitcode in action terraform plan

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -272,3 +272,6 @@ tf_data_dir
 
 disable_refresh
 : (default: `false`) - whether or not to disable refreshing state before `plan` and `apply` commands.
+
+detailed_exitcode
+: (default: `false`) - whether or not to use flag `-detailed-exitcode` with `plan` command.

--- a/main.go
+++ b/main.go
@@ -119,6 +119,11 @@ func main() {
 			Usage:  "whether or not to disable refreshing state before `plan` and `apply` commands",
 			EnvVar: "PLUGIN_DISABLE_REFRESH",
 		},
+		cli.BoolFlag{
+			Name:   "detailed_exitcode",
+			Usage:  "whether or not to use flag `-detailed-exitcode` with `plan` command",
+			EnvVar: "PLUGIN_DETAILED_EXITCODE",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -169,6 +174,7 @@ func run(c *cli.Context) error {
 			VarFiles:         c.StringSlice("var_files"),
 			TerraformDataDir: c.String("tf_data_dir"),
 			DisableRefresh:   c.Bool("disable_refresh"),
+			DetailedExitcode: c.Bool("detailed_exitcode"),
 		},
 		Netrc: Netrc{
 			Login:    c.String("netrc.username"),

--- a/plugin.go
+++ b/plugin.go
@@ -35,6 +35,7 @@ type (
 		VarFiles         []string
 		TerraformDataDir string
 		DisableRefresh   bool
+		DetailedExitcode bool
 	}
 
 	// Netrc is credentials for cloning
@@ -324,6 +325,9 @@ func tfPlan(config Config, destroy bool) *exec.Cmd {
 	}
 	if config.DisableRefresh {
 		args = append(args, "-refresh=false")
+	}
+	if config.DetailedExitcode {
+		args = append(args, "-detailed-exitcode")
 	}
 	return exec.Command(
 		"terraform",


### PR DESCRIPTION
This adds functionality to use flag `-detailed-exitcode` in action `terraform plan`.

```
-detailed-exitcode  Return detailed exit codes when the command exits. This
                      will change the meaning of exit codes to:
                      0 - Succeeded, diff is empty (no changes)
                      1 - Errored
                      2 - Succeeded, there is a diff

```
