### PR TITLE
Fix for handling targets

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -16,4 +16,5 @@ github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/urfave/cli v0.0.0-20161006035353-55f715e28c46 h1:EztUvugq7AA7F3lYLmtFQyvKdcY5pisPt10DqPjRCL8=
 github.com/urfave/cli v0.0.0-20161006035353-55f715e28c46/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+golang.org/x/sys v0.0.0-20161006025142-8d1157a43547 h1:lieXmNKpDj68llh9S3E0TfOPO3kHHn5jt5d/2nmylEc=
 golang.org/x/sys v0.0.0-20161006025142-8d1157a43547/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/plugin.go
+++ b/plugin.go
@@ -250,7 +250,7 @@ func tfApply(config Config) *exec.Cmd {
 		"apply",
 	}
 	for _, v := range config.Targets {
-		args = append(args, "--target", fmt.Sprintf("%s", v))
+		args = append(args, fmt.Sprintf("-target=%s", v))
 	}
 	if config.Parallelism > 0 {
 		args = append(args, fmt.Sprintf("-parallelism=%d", config.Parallelism))

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -89,7 +89,7 @@ func TestPlugin(t *testing.T) {
 				{
 					"with targets",
 					args{config: Config{Targets: []string{"target1", "target2"}}},
-					exec.Command("terraform", "apply", "--target", "target1", "--target", "target2", "plan.tfout"),
+					exec.Command("terraform", "apply", "-target=target1", "-target=target2", "plan.tfout"),
 				},
 			}
 


### PR DESCRIPTION
The targets yaml list was being processed as:
`terraform plan --target aws_s3_bucket.test --target module.foo.bar`

The correct usage is:
`terraform plan -target=aws_s3_bucket.test -target=module.foo.bar`

https://www.terraform.io/docs/cli/commands/plan.html#resource-targeting