### PR TITLE
Add tf-summarize integration & skipping tf init / cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 8.4-1.3.1 (2022-10-06)
+* Update embedded TF to `1.3.1`
+* Add the ability to `skip_init`
+  * Doesn't run `init` pre-cleanup of `.terraform/`
+  * Handful together with `s3-cache` plugin
+* Add the ability to `skip_cleanup`
+  * Doesn't remove `.terraform/` on finish
+  * Handful together with `s3-cache` plugin
+* Integrate [`tf-summarize`](https://github.com/dineshba/tf-summarize) into the plugin
+  * New `summarize` action - requires a generated plan file to be present
+  * Has bool options `draw`, `md`, `tree` and `separate_tree` in the `summarize_options` plugin setting to tune the output
+
 ## 8.3-1.0.2 (2021-07-09)
 * Update embedded TF to `1.0.2`
   * A continuation of `v0.15` release line but now following semver

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ ARG terraform_version
 RUN wget -q https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_linux_amd64.zip -O terraform.zip && \
   unzip terraform.zip -d /bin && \
   rm -f terraform.zip
+ARG summarize_version
+RUN curl -sL https://github.com/dineshba/tf-summarize/releases/download/v${summarize_version}/tf-summarize_linux_amd64.zip -osummarize.zip && \
+  unzip summarize.zip tf-summarize -d /bin && \
+  rm -f summarize.zip
 
 COPY --from=builder /go/bin/drone-terraform /bin/
 ENTRYPOINT ["/bin/drone-terraform"]

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -12,7 +12,7 @@ fi
 major=$(echo $tag | awk -F. '{print $1}')
 minor=$(echo $tag | awk -F. '{print $2}')
 
-tf_ver="1.0.2"
+tf_ver="1.3.1"
 sum_ver="0.2.2"
 
 echo "Confirm building images for:"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -13,11 +13,13 @@ major=$(echo $tag | awk -F. '{print $1}')
 minor=$(echo $tag | awk -F. '{print $2}')
 
 tf_ver="1.0.2"
+sum_ver="0.2.2"
 
 echo "Confirm building images for:"
 echo "  MAJOR: ${major}"
 echo "  MINOR: ${minor}"
 echo "  TF_VERSION: ${tf_ver}"
+echo "  SUM_VERSION: ${sum_ver}"
 
 read -p "Proceed? [Y/N] " ans
 
@@ -27,7 +29,7 @@ if [[ "$ans" != "Y" && "$ans" != "y" ]]; then
 fi
 
 set -x
-docker build -t jmccann/drone-terraform:latest --build-arg terraform_version=${tf_ver} .
+docker build -t jmccann/drone-terraform:latest --build-arg terraform_version=${tf_ver} --build-arg summarize_version=${sum_ver}.
 
 docker tag jmccann/drone-terraform:latest jmccann/drone-terraform:${major}
 docker tag jmccann/drone-terraform:latest jmccann/drone-terraform:${major}.${minor}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,11 @@ func main() {
 			EnvVar: "PLUGIN_INIT_OPTIONS",
 		},
 		cli.StringFlag{
+			Name:   "summarize_options",
+			Usage:  "options for the tf-summarize command. See https://github.com/dineshba/tf-summarize#usage",
+			EnvVar: "PLUGIN_SUMMARIZE_OPTIONS",
+		},
+		cli.StringFlag{
 			Name:   "fmt_options",
 			Usage:  "options for the fmt command. See https://www.terraform.io/docs/commands/fmt.html",
 			EnvVar: "PLUGIN_FMT_OPTIONS",
@@ -53,6 +58,16 @@ func main() {
 			Name:   "parallelism",
 			Usage:  "The number of concurrent operations as Terraform walks its graph",
 			EnvVar: "PLUGIN_PARALLELISM",
+		},
+		cli.BoolFlag{
+			Name:   "skip_init",
+			Usage:  "skip terraform init (useful for usage with s3-cache)",
+			EnvVar: "PLUGIN_SKIP_INIT",
+		},
+		cli.BoolFlag{
+			Name:   "skip_cleanup",
+			Usage:  "skip removal of .terraform/ (useful for usage with s3-cache)",
+			EnvVar: "PLUGIN_SKIP_CLEANUP",
 		},
 		cli.StringFlag{
 			Name:   "netrc.machine",
@@ -152,6 +167,8 @@ func run(c *cli.Context) error {
 	json.Unmarshal([]byte(c.String("init_options")), &initOptions)
 	fmtOptions := FmtOptions{}
 	json.Unmarshal([]byte(c.String("fmt_options")), &fmtOptions)
+	summarizeOptions := SummarizeOptions{}
+	json.Unmarshal([]byte(c.String("summarize_options")), &summarizeOptions)
 
 	plugin := Plugin{
 		Config: Config{
@@ -160,10 +177,13 @@ func run(c *cli.Context) error {
 			Secrets:          secrets,
 			InitOptions:      initOptions,
 			FmtOptions:       fmtOptions,
+			SummarizeOptions: summarizeOptions,
 			Cacert:           c.String("ca_cert"),
 			Sensitive:        c.Bool("sensitive"),
 			RoleARN:          c.String("role_arn_to_assume"),
 			RootDir:          c.String("root_dir"),
+			SkipInit:         c.Bool("skip_init"),
+			SkipCleanup:      c.Bool("skip_cleanup"),
 			Parallelism:      c.Int("parallelism"),
 			Targets:          c.StringSlice("targets"),
 			VarFiles:         c.StringSlice("var_files"),


### PR DESCRIPTION
I've decided to add few features. The crucial one is adding two settings:

* `skip_init`
* `skip_cleanup`

These two work together with `s3-cache` plugin, so when using separate pipelines you don't have to re-init the whole thing.

The other part is adding [`tf-summarize`](https://github.com/dineshba/tf-summarize) integration so that plans can be formatted nicely.