### PR TITLE
fix: use correct terraform argument `target`

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -250,7 +250,7 @@ func tfApply(config Config) *exec.Cmd {
 		"apply",
 	}
 	for _, v := range config.Targets {
-		args = append(args, "--target", fmt.Sprintf("%s", v))
+		args = append(args, "-target", fmt.Sprintf("%s", v))
 	}
 	if config.Parallelism > 0 {
 		args = append(args, fmt.Sprintf("-parallelism=%d", config.Parallelism))
@@ -309,7 +309,7 @@ func tfPlan(config Config, destroy bool) *exec.Cmd {
 	}
 
 	for _, v := range config.Targets {
-		args = append(args, "--target", fmt.Sprintf("%s", v))
+		args = append(args, "-target", fmt.Sprintf("%s", v))
 	}
 	args = append(args, varFiles(config.VarFiles)...)
 	args = append(args, vars(config.Vars)...)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -89,7 +89,7 @@ func TestPlugin(t *testing.T) {
 				{
 					"with targets",
 					args{config: Config{Targets: []string{"target1", "target2"}}},
-					exec.Command("terraform", "apply", "--target", "target1", "--target", "target2", "plan.tfout"),
+					exec.Command("terraform", "apply", "-target", "target1", "-target", "target2", "plan.tfout"),
 				},
 			}
 


### PR DESCRIPTION
This PR fix the use of target argument using double "-" instead of single one.

i.e

```bash
terraform -target

# instead of
terraform --target
```